### PR TITLE
fix: incorrect mimetype for selfhosted polyfill

### DIFF
--- a/src/runtime/selfhost.ts
+++ b/src/runtime/selfhost.ts
@@ -3,12 +3,16 @@ import { useRuntimeConfig } from '#imports'
 import {
   defineEventHandler,
   getHeader,
+  setHeader,
 } from 'h3'
 
 export default defineEventHandler((event) => {
   const config   = useRuntimeConfig()
   const features = (config.nupolyon.features ?? ['default']) as string[]
   const ua       = getHeader(event, 'User-Agent')
+
+  // Set proper mimetype for response
+  setHeader(event, 'Content-Type', 'application/javascript; charset=utf-8')
 
   return polyfill.getPolyfillString({
     uaString: ua,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch } from '@nuxt/test-utils'
+import { setup, fetch, $fetch } from '@nuxt/test-utils'
 
 describe('ssr', async () => {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
   })
 
-  it('renders the index page', async () => {
+  it('should render the index page', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
     expect(html).toContain('<div>basic</div>')
+  })
+
+  it('should return selfhosted polyfill with correct mimetype', async () => {
+    const res = await fetch('/_nupolyon/polyfill')
+    expect(res.headers.get('content-type')).toContain('application/javascript')
   })
 })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,7 +1,9 @@
-import MyModule from '../../../src/module'
+import Nupolyon from '../../../src/module'
 
 export default defineNuxtConfig({
   modules: [
-    MyModule
-  ]
+    Nupolyon
+  ],
+
+  nupolyon: { host: 'selfhost' },
 })


### PR DESCRIPTION
The mimetype for the selfhosted polyfill is not set, and thus defaults to `text/html`.
This results in an error when using proper security headers, e.g. set by `nuxt-security`.

Relevant chrome error:

> Refused to execute script from '/_nupolyon/polyfill' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.