### PR TITLE
chore(git): ignore yarn using whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,13 @@ node_modules
 .cache
 
 # Yarn
-**/.yarn/cache
-**/.yarn/*state*
+.yarn/*
+!.yarn/releases
+!.yarn/patches
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
 
 # Generated dirs
 dist


### PR DESCRIPTION
Use content as given by https://www.gitignore.io/api/yarn.

Just an idea, you could use https://www.gitignore.io/ to generate the full file as well. I use the following query for example: https://www.toptal.com/developers/gitignore/api/node,linux,macos,nuxtjs,windows

Feel free to close this PR if you'd like to keep everything as is or change the whole file. Whatever fits :wink: 