### PR TITLE
docs(readme): link detailed feature explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Find and replace all on all files (CMD+SHIFT+F):
 - ✅ &nbsp;[Automatic detection][polyfillist] based on browserslist target
 - ✅ &nbsp;Using [polyfill.io](https://polyfill.io) CDN, Custom CDN, or Self-Host
 
+See the detailed feature explanation here: [#58 (comment)](https://github.com/adenvt/nupolyon/issues/58#issuecomment-1676713711)
+
 ## Quick Setup
 
 1. Add `nupolyon` dependency to your project


### PR DESCRIPTION
As proposed in #58. Can be replaced by a `features` module option documentation if the implementation if decided on.