### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,7 @@ See the detailed feature explanation here: [#58 (comment)](https://github.com/ad
 1. Add `nupolyon` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nupolyon
-
-# Using yarn
-yarn add --dev nupolyon
-
-# Using npm
-npm install --save-dev nupolyon
+npx nuxi@latest module add nupolyon
 ```
 
 2. Add `nupolyon` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
